### PR TITLE
refactor: Add typed error enums for square and offset calculations

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -437,6 +437,7 @@ impl Board {
         Ok(squares)
     }
 
+    // add an offset to a square and validate that it is on the board
     fn add_offset_to_position(
         &self,
         pos: Square,
@@ -461,6 +462,7 @@ impl Board {
         }
     }
 
+    // Calculate an offset between two squares on the board
     fn get_offset_of_move(&self, old: Square, new: Square) -> Offset {
         Offset {
             rank: new.rank as isize - old.rank as isize,

--- a/src/board.rs
+++ b/src/board.rs
@@ -7,6 +7,7 @@ pub mod king;
 pub mod castling;
 mod straight_moving_piece;
 mod test_utils;
+mod errors;
 
 use crate::board::pawn::PawnMovement;
 use std::fmt;
@@ -16,6 +17,7 @@ use self::rook::RookMovement;
 use self::bishop::BishopMovement;
 use self::queen::QueenMovement;
 use self::king::KingMovement;
+use self::errors::*;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum PieceType {
@@ -70,45 +72,6 @@ pub fn get_piece_from_char(ch: char) -> Piece {
     }
 }
 
-#[derive(Debug)]
-enum Orientation {
-    Rank,
-    File,
-    Both,
-}
-
-#[derive(Debug)]
-enum InvalidOffsetError {
-    LessThanZero(Orientation, Offset),
-    InvalidSquare(InvalidSquareError)
-}
-
-impl Into<&'static str> for InvalidOffsetError  {
-    fn into(self) -> &'static str {
-        match self {
-            InvalidOffsetError::LessThanZero(Orientation::File, _) => "Invalid offset, resulting file is less than zero",
-            InvalidOffsetError::LessThanZero(_, _) => "Invalid offset, resulting rank is less than zero",
-            InvalidOffsetError::InvalidSquare(error) => error.into(),
-        }
-    }
-}
-
-#[derive(Debug)]
-enum InvalidSquareError {
-    OutOfBounds(Orientation, Square),
-}
-
-impl Into<&'static str> for InvalidSquareError {
-    fn into(self) -> &'static str {
-        "Square is out of bounds"
-    }
-}
-
-impl Into<InvalidOffsetError> for InvalidSquareError {
-    fn into(self) -> InvalidOffsetError {
-        InvalidOffsetError::InvalidSquare(self)
-    }
-}
 
 // Represents a square on the board
 //

--- a/src/board/errors.rs
+++ b/src/board/errors.rs
@@ -1,3 +1,6 @@
+use super::{Square, Offset};
+
+/// Helper enum to indicate whether a given error is referencing a row or column on the board
 #[derive(Debug)]
 pub enum Orientation {
     Rank,
@@ -5,9 +8,12 @@ pub enum Orientation {
     Both,
 }
 
+/// Gives an error when a offset calculation gives an unrepresentable result
 #[derive(Debug)]
 pub enum InvalidOffsetError {
+    /// Indicates that the resulting offset would be off the left or bottom side of the board
     LessThanZero(Orientation, Offset),
+    /// Indicates that the given square would be off the top or right side of the board
     InvalidSquare(InvalidSquareError)
 }
 
@@ -23,6 +29,7 @@ impl Into<&'static str> for InvalidOffsetError  {
 
 #[derive(Debug)]
 pub enum InvalidSquareError {
+    /// Indicates that the given square would be off the top or right side of the board
     OutOfBounds(Orientation, Square),
 }
 

--- a/src/board/errors.rs
+++ b/src/board/errors.rs
@@ -1,0 +1,39 @@
+#[derive(Debug)]
+pub enum Orientation {
+    Rank,
+    File,
+    Both,
+}
+
+#[derive(Debug)]
+pub enum InvalidOffsetError {
+    LessThanZero(Orientation, Offset),
+    InvalidSquare(InvalidSquareError)
+}
+
+impl Into<&'static str> for InvalidOffsetError  {
+    fn into(self) -> &'static str {
+        match self {
+            InvalidOffsetError::LessThanZero(Orientation::File, _) => "Invalid offset, resulting file is less than zero",
+            InvalidOffsetError::LessThanZero(_, _) => "Invalid offset, resulting rank is less than zero",
+            InvalidOffsetError::InvalidSquare(error) => error.into(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum InvalidSquareError {
+    OutOfBounds(Orientation, Square),
+}
+
+impl Into<&'static str> for InvalidSquareError {
+    fn into(self) -> &'static str {
+        "Square is out of bounds"
+    }
+}
+
+impl Into<InvalidOffsetError> for InvalidSquareError {
+    fn into(self) -> InvalidOffsetError {
+        InvalidOffsetError::InvalidSquare(self)
+    }
+}


### PR DESCRIPTION
Rewrite some of the functions on the board to return dedicated Error types instead of returning plain `&str`s. This makes it possible to get better information as to exactly what went wrong when calling a function.